### PR TITLE
Add option to disable the embedded app

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,14 +18,19 @@ module.exports = {
     app.options.storeConfigInMeta = false;
 
     // we start the app explicitly
-    app.options.autoRun = false;
+    app.options.autoRun = this._isAddonDisabled ?? false;
   },
 
   config(env, baseConfig) {
     this._rootURL = baseConfig.rootURL;
+    this._isAddonDisabled = baseConfig['ember-embedded-snippet'].disabled ?? false;
   },
 
   _process(appTree) {
+    if (this._isAddonDisabled) {
+      return appTree;
+    }
+
     const mergeTrees = require('broccoli-merge-trees');
     const ProcessHtmlPlugin = require('./lib/process-html');
 


### PR DESCRIPTION
There are use cases where we want to disable the embedded app based on variables at deployment time. This PR introduces this option. You can disable it by passing an option in the `config/environment.js`

```js
const ENV = {
  'ember-embedded-snippet': {
    disabled: true,
  },
};
```

Happy to get feedback or hear if there are other alternatives.